### PR TITLE
v2.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flashing-page-title-notification",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "flashing-page-title-notification",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "ISC",
       "devDependencies": {
         "eslint": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flashing-page-title-notification",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "A javascript plugin which allows easy use of creating a flashing page title for notification purposes.",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## v2.5.2

Maintenance release. **No change to shipped code** — `dist/` and `src/` are identical to 2.5.1.

### Included (already merged via #28)
- 🔒 `npm audit` fixes: 9 transitive devDependency vulnerabilities (4 high, 5 moderate)
- 👷 CI upgraded to Node 22.x/24.x with `actions/checkout@v4` + `actions/setup-node@v4` (fixes Node 16 deprecation + cache 400)

### This PR
- 🔖 Version bump `2.5.1` → `2.5.2`

After merge, publish to npm from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)